### PR TITLE
Dark mode first pass

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -3,10 +3,10 @@ import { ThemeProvider } from '@mui/material/styles';
 import CssBaseline from '@mui/material/CssBaseline';
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import Layout from './layout/Layout';
-import theme from './theme';
 import ErrorBoundary from './components/ErrorBoundary';
 import Loading from './components/Loading';
-
+import useMediaQuery from '@mui/material/useMediaQuery';
+import themeFactory from './theme/index';
 
 const HomePage = React.lazy(() => import('./pages/HomePage'));
 const CivIdlePage = React.lazy(() => import('./pages/CivIdle'));
@@ -21,6 +21,13 @@ const CivIdleScienceVsWorker = React.lazy(() => import('./pages/cividle/ScienceB
 
 
 function App() {
+  const prefersDarkMode = useMediaQuery('(prefers-color-scheme: dark)');
+
+  const theme = React.useMemo(
+    () => themeFactory(prefersDarkMode ? 'dark' : 'light'),
+    [prefersDarkMode],
+  );
+
   return (
     <ThemeProvider theme={theme}>
       <CssBaseline />

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -10,7 +10,7 @@ const Sidebar = () => {
   return (
     <Box sx={{ 
       width: 220, 
-      backgroundColor: '#f5f5f5', 
+      backgroundColor: 'background.elevated', 
       height: '100%',
       boxShadow: '2px 0 5px rgba(0,0,0,0.1)',
       overflowY: 'auto',

--- a/src/layout/Layout.js
+++ b/src/layout/Layout.js
@@ -10,7 +10,7 @@ const Layout = ({ children }) => {
       <Header />
       <Box sx={{ display: 'flex', flexGrow: 1, pt: '64px' }}>
         <Sidebar />
-        <Box component="main" sx={{ flexGrow: 1, p: 3, backgroundColor: 'white' }}>
+        <Box component="main" sx={{ flexGrow: 1, p: 3, }}>
           {children}
         </Box>
       </Box>

--- a/src/pages/Tile.js
+++ b/src/pages/Tile.js
@@ -36,7 +36,6 @@ const Tile = ({ title, description, imageSrc, route = '' }) => {
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'center',
-          bgcolor: 'white',
         }}
       >
         <img 

--- a/src/pages/cividle/GPEfficient.js
+++ b/src/pages/cividle/GPEfficient.js
@@ -20,7 +20,7 @@ const GPEfficient = () => {
 	const EfficiencyTooltip = ({ active, payload, label }) => {
 	  if (active && payload && payload.length) {
 		return (
-		  <div style={{ backgroundColor: 'white', padding: '10px', border: '1px solid #ccc' }}>
+		  <div style={{ backgroundColor: 'white', color: '#202020', padding: '10px', border: '1px solid #ccc' }}>
 			<p>{`GP Count: ${label}`}</p>
 			<p>{`Efficiency: ${payload[0].value.toFixed(2)} GP/Hour`}</p>
 		  </div>

--- a/src/pages/cividle/ProductChainGraph.js
+++ b/src/pages/cividle/ProductChainGraph.js
@@ -28,6 +28,7 @@ const CustomNode = ({ data }) => (
     background: '#eee',
     border: '1px solid #ddd',
     borderRadius: '50%',
+    color: '#202020',
     padding: '10px',
     width: '150px',
     height: '150px',

--- a/src/theme/index.js
+++ b/src/theme/index.js
@@ -1,7 +1,25 @@
 import { createTheme } from '@mui/material/styles';
 
-const theme = createTheme({
-  // You can customize your theme here
-});
 
-export default theme;
+const themeFactory = (mode) => {
+  return createTheme({
+    palette: {
+      mode: mode,
+      ...(mode === 'light'
+        ? {
+          background: {
+            main: '#f0f0f0',
+            elevated: '#f5f5f5',
+          },
+        }
+        : {
+          background: {
+            main: '#121212',
+            elevated: '#1e1e1e',
+          },
+        }),
+    },
+  });
+}
+
+export default themeFactory;


### PR DESCRIPTION
## Overview
A first pass at dark mode - I tried to keep it as minimal as possible. This reads the "prefers-color-scheme: dark" media query to decide whether to present the user with dark mode or light mode - meaning it matches the system default

## Considerations
- A three-way toggle could be introduced to allow the user to explicitly choose between light/dark/system.
- I'm not 100% sure I found everywhere in the app that needed to be updated to be legible in dark mode, so you'll probably want to double-check it yourself.